### PR TITLE
removed chardet dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,6 @@ FileChooserThumbView
 The FileChooserThumbView widget is similar to FileChooserIconView,
 but if possible it shows a thumbnail instead of a normal icon.
 
-Dependencies
-------------
-
-The module "chardet" is required to use this widget: if you don't have
-it installed, install it. It's installed by default in Ubuntu.
-
 Usage
 -----
 

--- a/__init__.py
+++ b/__init__.py
@@ -32,7 +32,6 @@ import shutil
 import subprocess
 from threading import Thread
 from os.path import join, exists, dirname
-from chardet import detect as chardetect
 from tempfile import mktemp, mkdtemp
 
 from kivy.app import App
@@ -357,11 +356,6 @@ class FileChooserThumbView(FileChooserController):
         else:
             label = size + " - " + temp
         return label
-
-    def _unicode_noerrs(self, string):
-        if not string:
-            return u""
-        return unicode(string, encoding=chardetect(string)["encoding"])
 
 
 class ThreadedThumbnailGenerator(object):


### PR DESCRIPTION
I checked the code and found out that `charted` module was imported but never used. `_unicode_noerrs()` method that used `chardetect` was declared but left unused in `FileChooserThumbView` so I removed it completely.
This makes `FileChooserThumbView` finally without any dependencies :).