### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -373,7 +373,7 @@ class ThreadedThumbnailGenerator(object):
         self.thumbnail_queue.append([widget, ctx, func])
 
     def run(self):
-        if self.thread is None or not self.thread.isAlive():
+        if self.thread is None or not self.thread.is_alive():
             self.thread = Thread(target=self._loop)
             self.thread.start()
 


### PR DESCRIPTION
Fixes #16 . The is_alive method is present in both Python 2 and 3.